### PR TITLE
4-Fixed cached tiles failing to load

### DIFF
--- a/debug.js
+++ b/debug.js
@@ -37,7 +37,7 @@ class Debug {
   constructor(win, logPath) {
     this.win = win;
     this.useDebug = false;
-    if (!logPath) logPath = "debug.log";
+    if (!logPath) logPath = "./debug.log";
     this.ws = fs.createWriteStream(logPath);
   }
 


### PR DESCRIPTION
Description of changes:

Any file paths that were supposed to be relative to the executable were changed to begin with "./", and any file paths that were supposed to be relative to main.js were changed to use "__dirname" with path.join. The use of "./" as opposed to "__dirname" was the root cause of the tiles failing to load because they were incorrectly placed relative to the executable rather than relative to main.js.