### PR TITLE
Implement tile cache toggle

### DIFF
--- a/default-config.json
+++ b/default-config.json
@@ -32,7 +32,7 @@
 		"type": "toggle"
 	},
 	"tileCache": {
-		"name": "Toggle Tile Caching (Not Implemented)",
+		"name": "Toggle Tile Caching",
 		"description": "Turn off caching of map tiles to the disk. If disabled, the map may not work when offline.",
 		"value": true,
 		"type": "toggle"

--- a/src/libraries/map/map.js
+++ b/src/libraries/map/map.js
@@ -13,7 +13,11 @@ const buildMap = (id) => {
     zoom: 5,
   });
 
-  L.tileLayer.provider("OpenTopoMap").addTo(map);
+  api.getSettings().then((config) => {
+    L.tileLayer
+      .provider("OpenTopoMap", { enableCache: config.tileCache.value })
+      .addTo(map);
+  });
 
   markers.addTo(map);
 


### PR DESCRIPTION
This pull request finally fully implements manual tile cache toggling. The setting was added a while ago, but the feature itself was not implemented. Turning on the setting will enable the manual map tile cache, which will ensure map tiles are stored locally as long as the cache is not filled. Turning off the setting disables the manual cache and instead relies on the built in browser cache.

Closes #10 

## Major Changes
- Toggle for manual tile cache is now functional